### PR TITLE
Add DELAYLOGIN description

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,12 @@
 #   Default: no
 #
 # [*DELAYLOGIN*]
+#   Normally, the system will not let non-root users log in until the boot
+#   process is complete and the system has finished safely switching to the
+#   default runlevel (2). However, some operating systems allow login to occur
+#   at an earlier stage, namely just after inetd has started. Ensures this
+#   isn't possible.
+#   Default: no
 #
 # [*UTC*]
 #   Governs how the BIOS clock is read and written to.


### PR DESCRIPTION
The DELAYLOGIN option ensures that authentication can only occur after the system has fully booted, and not before - at around the time inetd has finished starting - as is the case in some modern operating systems.

Adds description.
Fixes #3.
