### PR TITLE
Add details of operating system support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,12 @@
   "source": "https://github.com/ajlanghorn/puppet-rcs",
   "project_page": "https://github.com/ajlanghorn/puppet-rcs",
   "issues_url": "https://github.com/ajlanghorn/puppet-rcs/issues",
+  "operatingsystem_support": [
+    {
+     "operatingsystem":"Ubuntu",
+     "operatingsystemrelease": [ "14.04", "12.04" ]
+    }
+  ]
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
   ]


### PR DESCRIPTION
The Puppet Forge metadata quality score can be improved by adding details of the support for different operating systems.

Since this is a quick fix to make, and since this module has only been tested against Ubuntu 12.04 and 14.04, it was good to do it.
