### PR TITLE
Fix syntaxt issue in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,4 +17,3 @@
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0"}
   ]
 }
-

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
      "operatingsystem":"Ubuntu",
      "operatingsystemrelease": [ "14.04", "12.04" ]
     }
-  ]
+  ],
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0"}
   ]


### PR DESCRIPTION
The metadata.json file was syntactically invalid because I wasn't including a comma on L15. Also cleared up a rogue newline at the end of the file.
