### PR TITLE
Re-factor ERB template

### DIFF
--- a/templates/etc/default/rcS.erb
+++ b/templates/etc/default/rcS.erb
@@ -2,19 +2,19 @@
 # THIS FILE IS MANAGED BY PUPPET
 
 # Delete files in /tmp during boot older than TMPTIME days
-  TMPTIME=<%= @tmptime %>
+  TMPTIME=<%= @TMPTIME %>
 
 # Spawn sulogin at boot, continue boot if not used within 30s
-  SULOGIN=<%= @sulogin %>
+  SULOGIN=<%= @SULOGIN %>
 
 # Do not allow users to login until boot has completed
-  DELAYLOGIN=<%= @delaylogin %>
+  DELAYLOGIN=<%= @DELAYLOGIN %>
 
 # Assume that BIOS time is UTC
-  UTC=<%= @utc %>
+  UTC=<%= @UTC %>
 
 # Verbose output during boot process
-  VERBOSE=<%= @verbose %>
+  VERBOSE=<%= @VERBOSE %>
 
 # Automatically repair filesystems with inconsistencies during boot
-  FSCKFIX=<%= @fsckfix %>
+  FSCKFIX=<%= @FSCKFIX %>

--- a/templates/etc/default/rcS.erb
+++ b/templates/etc/default/rcS.erb
@@ -2,43 +2,19 @@
 # THIS FILE IS MANAGED BY PUPPET
 
 # Delete files in /tmp during boot older than TMPTIME days
-<% if @tmptime != nil -%>
   TMPTIME=<%= @tmptime %>
-<% else %>
-  TMPTIME=7
-<% end -%>
 
 # Spawn sulogin at boot, continue boot if not used within 30s
-<% if @tmptime != nil -%>
   SULOGIN=<%= @sulogin %>
-<% else %>
-  SULOGIN=no
-<% end -%>
 
 # Do not allow users to login until boot has completed
-<% if @delaylogin != nil -%>
   DELAYLOGIN=<%= @delaylogin %>
-<% else %>
-  DELAYLOGIN=no
-<% end -%>
 
 # Assume that BIOS time is UTC
-<% if @utc !=nil -%>
   UTC=<%= @utc %>
-<% else -%>
-  UTC=yes
-<% end -%>
 
 # Verbose output during boot process
-<% if @verbose !=nil -%>
   VERBOSE=<%= @verbose %>
-<% else -%>
-  VERBOSE=no
-<% end -%>
 
 # Automatically repair filesystems with inconsistencies during boot
-<% if @fsckfix !=nil -%>
   FSCKFIX=<%= @fsckfix %>
-<% else -%>
-  FSCKFIX=no
-<% end -%>


### PR DESCRIPTION
Given that defaults are provided in `init.pp`, there are never any conditions where the value of each variable will not be given by either the user or defined by this module as a default. Remove the conditional statements as they'll never be met.

Also, it transpires that ERB cares a lot about capitalisation (that, or I don't, and so I assumed it wouldn't - bad Andrew!). This meant that the values weren't always being overridden in the ERB template during catalogue compilation if some were provided.
