### PR TITLE
Explicitly upcase rcS option values

### DIFF
--- a/templates/etc/default/rcS.erb
+++ b/templates/etc/default/rcS.erb
@@ -5,16 +5,16 @@
   TMPTIME=<%= @tmptime %>
 
 # Spawn sulogin at boot, continue boot if not used within 30s
-  SULOGIN=<%= @sulogin %>
+  SULOGIN=<%= @sulogin.upcase %>
 
 # Do not allow users to login until boot has completed
-  DELAYLOGIN=<%= @delaylogin %>
+  DELAYLOGIN=<%= @delaylogin.upcase %>
 
 # Assume that BIOS time is UTC
-  UTC=<%= @utc %>
+  UTC=<%= @utc.upcase %>
 
 # Verbose output during boot process
-  VERBOSE=<%= @verbose %>
+  VERBOSE=<%= @verbose.upcase %>
 
 # Automatically repair filesystems with inconsistencies during boot
-  FSCKFIX=<%= @fsckfix %>
+  FSCKFIX=<%= @fsckfix.upcase %>


### PR DESCRIPTION
Values passed to options represented as strings inside /etc/default/rcS
should be capitalised as the default /etc/default/rcS file in Ubuntu has
the options capitalised. Options represented as integers shouldn't have
this method applied because it makes no sense to do so.

Fix this using the `upcase` method on the `string` object.
