### PR TITLE
Upcase ERB template values

### DIFF
--- a/spec/classes/rcs_spec.rb
+++ b/spec/classes/rcs_spec.rb
@@ -27,13 +27,33 @@ describe 'rcs', :type => :class do
     end
   end
 
+  context 'sulogin is set to YES' do
+    let(:params) {{
+      :sulogin => 'YES',
+    }}
+    it do
+      is_expected.to contain_file('/etc/default/rcS') \
+        .with_content(/^  SULOGIN=YES$/)
+    end
+  end
+
   context 'sulogin is set to yes' do
     let(:params) {{
       :sulogin => 'yes',
     }}
     it do
       is_expected.to contain_file('/etc/default/rcS') \
-        .with_content(/^  SULOGIN=yes$/)
+        .with_content(/^  SULOGIN=YES$/)
+    end
+  end
+
+  context 'delaylogin is set to YES' do
+    let(:params) {{
+      :delaylogin => 'YES',
+    }}
+    it do
+      is_expected.to contain_file('/etc/default/rcS') \
+        .with_content(/^  DELAYLOGIN=YES$/)
     end
   end
 
@@ -43,7 +63,17 @@ describe 'rcs', :type => :class do
     }}
     it do
       is_expected.to contain_file('/etc/default/rcS') \
-        .with_content(/^  DELAYLOGIN=yes$/)
+        .with_content(/^  DELAYLOGIN=YES$/)
+    end
+  end
+
+  context 'utc is set to NO' do
+    let(:params) {{
+      :utc => 'NO',
+    }}
+    it do
+      is_expected.to contain_file('/etc/default/rcS') \
+        .with_content(/^  UTC=NO$/)
     end
   end
 
@@ -53,7 +83,17 @@ describe 'rcs', :type => :class do
     }}
     it do
       is_expected.to contain_file('/etc/default/rcS') \
-        .with_content(/^  UTC=no$/)
+        .with_content(/^  UTC=NO$/)
+    end
+  end
+
+  context 'verbose is set to YES' do
+    let(:params) {{
+      :verbose => 'YES'
+    }}
+    it do
+      is_expected.to contain_file('/etc/default/rcS') \
+        .with_content(/^  VERBOSE=YES$/)
     end
   end
 
@@ -63,7 +103,17 @@ describe 'rcs', :type => :class do
     }}
     it do
       is_expected.to contain_file('/etc/default/rcS') \
-        .with_content(/^  VERBOSE=yes$/)
+        .with_content(/^  VERBOSE=YES$/)
+    end
+  end
+
+  context 'fsckfix is set to YES' do
+    let(:params) {{
+      :fsckfix => 'YES'
+    }}
+    it do
+      is_expected.to contain_file('/etc/default/rcS') \
+        .with_content(/^  FSCKFIX=YES$/)
     end
   end
 
@@ -73,7 +123,7 @@ describe 'rcs', :type => :class do
     }}
     it do
       is_expected.to contain_file('/etc/default/rcS') \
-        .with_content(/^  FSCKFIX=yes$/)
+        .with_content(/^  FSCKFIX=YES$/)
     end
   end
 

--- a/templates/etc/default/rcS.erb
+++ b/templates/etc/default/rcS.erb
@@ -5,16 +5,16 @@
   TMPTIME=<%= @tmptime %>
 
 # Spawn sulogin at boot, continue boot if not used within 30s
-  SULOGIN=<%= @sulogin %>
+  SULOGIN=<%= @sulogin.upcase %>
 
 # Do not allow users to login until boot has completed
-  DELAYLOGIN=<%= @delaylogin %>
+  DELAYLOGIN=<%= @delaylogin.upcase %>
 
 # Assume that BIOS time is UTC
-  UTC=<%= @utc %>
+  UTC=<%= @utc.upcase %>
 
 # Verbose output during boot process
-  VERBOSE=<%= @verbose %>
+  VERBOSE=<%= @verbose.upcase %>
 
 # Automatically repair filesystems with inconsistencies during boot
-  FSCKFIX=<%= @fsckfix %>
+  FSCKFIX=<%= @fsckfix.upcase %>


### PR DESCRIPTION
By default, Ubuntu presents these as upcased on disk. We should, therefore, upcase them in this template to match that convention. Also, adds some RSpec tests for both variants in order that Travis can run them.
