### PR TITLE
Remove ajlanghorn ownership references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ajlanghorn/rcs
+# alphagov/rcs
 
 A Puppet module for configuring `/etc/default/rcS`, a script to control the
 behaviour of boot-time scripts.
@@ -12,7 +12,7 @@ If you're using a Puppet package managment system such as
 [librarian-puppet](https://github.com/rodjek/librarian-puppet), you can
 include this module in your Puppetfile as such:
 
-`mod ajlanghorn/rcs`
+`mod alphagov/rcs`
 
 ### Configuration
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,26 +36,6 @@
 #   Automatically repair filesystems with inconsistencies during boot.
 #   Default: NO
 #
-# === Authors
-#
-# Andrew Langhorn <andrew@ajlanghorn.com>
-#
-# === Copyright
-#
-# Copyright 2015 Andrew Langhorn, unless otherwise noted.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 class rcs(
   $tmptime      = '0',
   $sulogin      = 'NO',

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
-  "name": "ajlanghorn-rcs",
+  "name": "alphagov-rcs",
   "version": "0.1.1",
-  "author": "Andrew Langhorn",
+  "author": "Government Digital Service",
   "summary": "Manage Ubuntu rCS boot script behaviour using Puppet.",
   "license": "Apache-2.0",
-  "source": "https://github.com/ajlanghorn/puppet-rcs",
-  "project_page": "https://github.com/ajlanghorn/puppet-rcs",
-  "issues_url": "https://github.com/ajlanghorn/puppet-rcs/issues",
+  "source": "https://github.com/alphagov/puppet-rcs",
+  "project_page": "https://github.com/alphagov/puppet-rcs",
+  "issues_url": "https://github.com/alphagov/puppet-rcs/issues",
   "operatingsystem_support": [
     {
      "operatingsystem":"Ubuntu",


### PR DESCRIPTION
During development, I owned this module on my personal GitHub account. Now
this is in active use, it's been transferred to alphagov. Fixes #17 which
was raised to address this.
